### PR TITLE
Documentation polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Compile [Twig](https://github.com/twigphp/Twig) templates with [gulp](https://github.com/gulpjs/gulp). Build upon [Twing](https://github.com/ericmorand/twing).
 
+Requires [Node.js](https://github.com/nodejs/node) ≥ 7.6.0
+
 ## Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,23 +2,23 @@
 
 [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage percentage][coveralls-image]][coveralls-url]
 
-Compile Twig templates with Gulp. Build upon [Twing](https://github.com/ericmorand/twing).
+Compile [Twig](https://github.com/twigphp/Twig) templates with [gulp](https://github.com/gulpjs/gulp). Build upon [Twing](https://github.com/ericmorand/twing).
 
 ## Installation
 
 ```bash
-npm install twing gulp-twing --save-dev
+npm install twing gulp-twing --save
 ```
 
 ## Why do I need to install Twing?
 
-gulp-twing declares Twing as a peer dependency. It permits using any version of Twing (starting with version 0.4.0) with gulp-twing and profit from the latest features without having to wait for gulp-twing to catch-up.
+gulp-twing declares Twing as a peer dependency. It permits using any version of Twing (starting with version 0.4.0) with gulp-twing and profits from the latest features without having to wait for gulp-twing to catch up.
 
 ## Usage
 
-`let gulpTwing = require('gulp-twing');`
+`var twing = require('gulp-twing');`
 
-### gulpTwing(env, data, options)
+### twing(env, data, options)
 
 Return an object transform stream that expects entry filenames.
 
@@ -27,7 +27,7 @@ Return an object transform stream that expects entry filenames.
   A Twing environment. See [Twing documentation](https://ericmorand.github.io/twing/api.html) for details.
 
 * data
- 
+
   A hash of data passed to the render function of the template. See [Twing documentation](https://ericmorand.github.io/twing/api.html#rendering-templates) for details.
 
 * options
@@ -35,7 +35,7 @@ Return an object transform stream that expects entry filenames.
   An optional hash of options. The following options are supported:
 
   * outputExt
-  
+
     The output file extension including the `.`. Defaults to `.html`.
 
 ### Examples
@@ -44,12 +44,12 @@ The following examples all require importing gulp, gulp-twing, and Twing, and se
 
 ```javascript
 // top of gulpfile.js
-let gulp = require('gulp');
-let gulpTwing = require('gulp-twing');
+var gulp = require('gulp');
+var twing = require('gulp-twing');
 
-let Twing = require('twing');
-let loader = new Twing.TwingLoaderFilesystem('/');
-let env = new Twing.TwingEnvironment(loader);
+var Twing = require('twing');
+var loader = new Twing.TwingLoaderFilesystem('/');
+var env = new Twing.TwingEnvironment(loader);
 ```
 
 #### Basic usage
@@ -58,9 +58,9 @@ To compile all `.twig` files in the source directory `src/` saving the output as
 
 ```javascript
 // in gulpfile.js
-function twing() {
+function twig() {
     return gulp.src('src/**/*.twig')
-        .pipe(gulpTwing(env))
+        .pipe(twing(env))
         .pipe(gulp.dest('dest'))
 }
 ```
@@ -70,8 +70,8 @@ function twing() {
 To expose the above function to the command line in gulp 3 or gulp 4, use `gulp.task`:
 
 ```javascript
-// in twing()
-gulp.task('twing', twing);
+// in twig()
+gulp.task('twig', twig);
 ```
 
 Call the function with the command `gulp twing`.
@@ -79,8 +79,8 @@ Call the function with the command `gulp twing`.
 If you don't need to support gulp 3, you can use the more terse gulp 4 syntax
 
 ```javascript
-// in twing()
-gulp.task(twing);
+// in twig()
+gulp.task(twig);
 ```
 
 #### Classic gulp syntax
@@ -89,9 +89,9 @@ It may be convenient to use the classic syntax, for example when migrating an ol
 
 ```javascript
 // in gulpfile.js
-gulp.task('twing', function() {
+gulp.task('twig', function() {
     return gulp.src('src/**/*.twig')
-        .pipe(gulpTwing(env))
+        .pipe(twing(env))
         .pipe(gulp.dest('dest'))
 });
 ```
@@ -118,9 +118,9 @@ use
 
 ```javascript
 // in gulpfile.js
-function twing() {
+function twig() {
     return gulp.src('src/**/*.twig')
-        .pipe(gulpTwing(env, {foo: 'bar'}))
+        .pipe(twing(env, {foo: 'bar'}))
         .pipe(gulp.dest('dest'))
 }
 ```
@@ -138,9 +138,9 @@ Use gulp-twing's `outputExt` option when applying the same file extension change
 
 // src contains only *.css.twig and *.html.twig templates
 
-function twing() {
+function twig() {
     return gulp.src('src/**/*.twig')
-        .pipe(gulpTwing(env, {}, {outputExt: ''}))
+        .pipe(twing(env, {}, {outputExt: ''}))
         .pipe(gulp.dest('dest'))
 }
 
@@ -155,14 +155,14 @@ To compile index.css.twig, index.html.twig, and foo.twig saving the output to in
 
 ```javascript
 // in gulpfile.js
-let gulpRename = require('gulp-rename');
+var rename = require('gulp-rename');
 
 // src contains foo.twig, index.css.twig and index.html.twig
 
-function twing() {
+function twig() {
     gulp.src('src/**/*.twig')
-        .pipe(gulpRename(function(path) {
-        .pipe(gulpTwing(env))
+        .pipe(twing(env))
+        .pipe(rename(function(path) {
             if (path.basename.indexOf('.') > -1) {
                 path.extname = '';
             }
@@ -177,14 +177,14 @@ By combining `gulp-rename` and `outputExt`, you can compile index.css.twig, inde
 
 ```javascript
 // in gulpfile.js
-let gulpRename = require('gulp-rename');
+var rename = require('gulp-rename');
 
 // src contains foo.twig, index.css.twig and index.html.twig
 
-function twing() {
+function twig() {
     gulp.src('src/**/*.twig')
-        .pipe(gulpRename(function(path) {
-        .pipe(gulpTwing(env, {}, {outputExt: '.ext'}))
+        .pipe(twing(env, {}, {outputExt: '.ext'}))
+        .pipe(rename(function(path) {
             if (path.basename.indexOf('.') > -1) {
                 path.extname = '';
             }

--- a/README.md
+++ b/README.md
@@ -40,18 +40,24 @@ Return an object transform stream that expects entry filenames.
 
 ### Examples
 
-#### Basic usage
-
-To compile all `.twig` files in the source directory `src/` saving the output as `.html` in the destination directory `dest/`, use
+The following examples all require importing gulp, gulp-twing, and Twing, and setting the Twing loader and env:
 
 ```javascript
+// top of gulpfile.js
 let gulp = require('gulp');
 let gulpTwing = require('gulp-twing');
 
 let Twing = require('twing');
 let loader = new Twing.TwingLoaderFilesystem('/');
 let env = new Twing.TwingEnvironment(loader);
+```
 
+#### Basic usage
+
+To compile all `.twig` files in the source directory `src/` saving the output as `.html` in the destination directory `dest/`, use
+
+```javascript
+// in gulpfile.js
 function twing() {
     return gulp.src('src/**/*.twig')
         .pipe(gulpTwing(env))
@@ -64,6 +70,7 @@ function twing() {
 To expose the above function to the command line in gulp 3 or gulp 4, use `gulp.task`:
 
 ```javascript
+// in twing()
 gulp.task('twing', twing);
 ```
 
@@ -72,6 +79,7 @@ Call the function with the command `gulp twing`.
 If you don't need to support gulp 3, you can use the more terse gulp 4 syntax
 
 ```javascript
+// in twing()
 gulp.task(twing);
 ```
 
@@ -80,6 +88,7 @@ gulp.task(twing);
 It may be convenient to use the classic syntax, for example when migrating an older gulp project's Twig compilation to Twing. This is not recommended for new projects as it is not supported by gulp 4.
 
 ```javascript
+// in gulpfile.js
 gulp.task('twing', function() {
     return gulp.src('src/**/*.twig')
         .pipe(gulpTwing(env))
@@ -108,13 +117,7 @@ bar
 use
 
 ```javascript
-let gulp = require('gulp');
-let gulpTwing = require('gulp-twing');
-
-let Twing = require('twing');
-let loader = new Twing.TwingLoaderFilesystem('/');
-let env = new Twing.TwingEnvironment(loader);
-
+// in gulpfile.js
 function twing() {
     return gulp.src('src/**/*.twig')
         .pipe(gulpTwing(env, {foo: 'bar'}))
@@ -131,23 +134,17 @@ By default, gulp-twing appends `.html` to compiled files. Changing this behavior
 Use gulp-twing's `outputExt` option when applying the same file extension change to all source files. For example, use `outputExt: '.ext'` to compile example.twig as example.ext. Or use `outputExt: ''` to compile example.ext.twig as example.ext.
 
 ```javascript
-let gulp = require('gulp');
-let gulpTwing = require('gulp-twing');
-
-let Twing = require('twing');
-let loader = new Twing.TwingLoaderFilesystem('/');
-let env = new Twing.TwingEnvironment(loader);
+// in gulpfile.js
 
 // src contains only *.css.twig and *.html.twig templates
 
 function twing() {
     return gulp.src('src/**/*.twig')
-        .pipe(gulpTwing(env, {foo: 'bar'}, {outputExt: ''}))
+        .pipe(gulpTwing(env, {}, {outputExt: ''}))
         .pipe(gulp.dest('dest'))
 }
 
 // dest will contain *.css and *.html files
-
 ```
 
 #### Loosely named templates
@@ -157,20 +154,15 @@ If you need more control on the name of the ouput, use [gulp-rename](https://www
 To compile index.css.twig, index.html.twig, and foo.twig saving the output to index.css, index.html, and foo.html, use
 
 ```javascript
-let gulp = require('gulp');
-let gulpTwing = require('gulp-twing');
+// in gulpfile.js
 let gulpRename = require('gulp-rename');
-
-let Twing = require('twing');
-let loader = new Twing.TwingLoaderFilesystem('/');
-let env = new Twing.TwingEnvironment(loader);
 
 // src contains foo.twig, index.css.twig and index.html.twig
 
 function twing() {
     gulp.src('src/**/*.twig')
-        .pipe(gulpTwing(env, {foo: 'bar'}))
         .pipe(gulpRename(function(path) {
+        .pipe(gulpTwing(env))
             if (path.basename.indexOf('.') > -1) {
                 path.extname = '';
             }
@@ -184,20 +176,15 @@ function twing() {
 By combining `gulp-rename` and `outputExt`, you can compile index.css.twig, index.html.twig, foo.twig saving the output to index.css, index.html, and foo.ext:
 
 ```javascript
-let gulp = require('gulp');
-let gulpTwing = require('gulp-twing');
+// in gulpfile.js
 let gulpRename = require('gulp-rename');
-
-let Twing = require('twing');
-let loader = new Twing.TwingLoaderFilesystem('/');
-let env = new Twing.TwingEnvironment(loader);
 
 // src contains foo.twig, index.css.twig and index.html.twig
 
 function twing() {
     gulp.src('src/**/*.twig')
-        .pipe(gulpTwing(env, {foo: 'bar'}, {outputExt: '.ext'}))
         .pipe(gulpRename(function(path) {
+        .pipe(gulpTwing(env, {}, {outputExt: '.ext'}))
             if (path.basename.indexOf('.') > -1) {
                 path.extname = '';
             }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Return an object transform stream that expects entry filenames.
 
 #### Basic usage
 
+To compile all `.twig` files in the source directory `src/` saving the output as `.html` in the destination directory `dest/`, use
+
 ```javascript
 let gulp = require('gulp');
 let gulpTwing = require('gulp-twing');
@@ -50,14 +52,83 @@ let Twing = require('twing');
 let loader = new Twing.TwingLoaderFilesystem('/');
 let env = new Twing.TwingEnvironment(loader);
 
-gulp
-    .src('src/**/*.twig')
-    .pipe(gulpTwing(env, {foo: 'bar'}))
-    .pipe(gulp.dest('dest'))
-;
+function twing() {
+    return gulp.src('src/**/*.twig')
+        .pipe(gulpTwing(env))
+        .pipe(gulp.dest('dest'))
+}
 ```
 
-#### Strictly named templates
+#### CLI usage
+
+To expose the above function to the command line in gulp 3 or gulp 4, use `gulp.task`:
+
+```javascript
+gulp.task('twing', twing);
+```
+
+Call the function with the command `gulp twing`.
+
+If you don't need to support gulp 3, you can use the more terse gulp 4 syntax
+
+```javascript
+gulp.task(twing);
+```
+
+#### Classic gulp syntax
+
+It may be convenient to use the classic syntax, for example when migrating an older gulp project's Twig compilation to Twing. This is not recommended for new projects as it is not supported by gulp 4.
+
+```javascript
+gulp.task('twing', function() {
+    return gulp.src('src/**/*.twig')
+        .pipe(gulpTwing(env))
+        .pipe(gulp.dest('dest'))
+});
+```
+
+#### Passing data
+
+You can pass data to Twig templates during compilation with the gulp-twing's data hash.
+
+For example, to compile the template
+
+```twig
+{# src/example.twig #}
+{{ foo }}
+```
+
+to
+
+```html
+<!-- dest/example.twig -->
+bar
+```
+
+use
+
+```javascript
+let gulp = require('gulp');
+let gulpTwing = require('gulp-twing');
+
+let Twing = require('twing');
+let loader = new Twing.TwingLoaderFilesystem('/');
+let env = new Twing.TwingEnvironment(loader);
+
+function twing() {
+    return gulp.src('src/**/*.twig')
+        .pipe(gulpTwing(env, {foo: 'bar'}))
+        .pipe(gulp.dest('dest'))
+}
+```
+
+#### Renaming files
+
+By default, gulp-twing appends `.html` to compiled files. Changing this behavior is easy.
+
+##### Strictly named templates
+
+Use gulp-twing's `outputExt` option when applying the same file extension change to all source files. For example, use `outputExt: '.ext'` to compile example.twig as example.ext. Or use `outputExt: ''` to compile example.ext.twig as example.ext.
 
 ```javascript
 let gulp = require('gulp');
@@ -69,11 +140,11 @@ let env = new Twing.TwingEnvironment(loader);
 
 // src contains only *.css.twig and *.html.twig templates
 
-gulp
-    .src('src/**/*.twig')
-    .pipe(gulpTwing(env, {foo: 'bar'}, {outputExt: ''}))
-    .pipe(gulp.dest('dest'))
-;
+function twing() {
+    return gulp.src('src/**/*.twig')
+        .pipe(gulpTwing(env, {foo: 'bar'}, {outputExt: ''}))
+        .pipe(gulp.dest('dest'))
+}
 
 // dest will contain *.css and *.html files
 
@@ -82,6 +153,8 @@ gulp
 #### Loosely named templates
 
 If you need more control on the name of the ouput, use [gulp-rename](https://www.npmjs.com/package/gulp-rename).
+
+To compile index.css.twig, index.html.twig, and foo.twig saving the output to index.css, index.html, and foo.html, use
 
 ```javascript
 let gulp = require('gulp');
@@ -94,19 +167,45 @@ let env = new Twing.TwingEnvironment(loader);
 
 // src contains foo.twig, index.css.twig and index.html.twig
 
-gulp
-    .src(['src/**/*.twig'])
-    .pipe(gulpTwing(env, {foo: 'bar'}))
-    .pipe(gulpRename(function(path) {
-        if (path.basename.indexOf('.') > -1) {
-            path.extname = '';
-        }
-    }))
-    .pipe(gulp.dest('dest'))
-;
+function twing() {
+    gulp.src('src/**/*.twig')
+        .pipe(gulpTwing(env, {foo: 'bar'}))
+        .pipe(gulpRename(function(path) {
+            if (path.basename.indexOf('.') > -1) {
+                path.extname = '';
+            }
+        }))
+        .pipe(gulp.dest('dest'))
+}
 
 // dest will contain foo.html, index.css and index.html
+```
 
+By combining `gulp-rename` and `outputExt`, you can compile index.css.twig, index.html.twig, foo.twig saving the output to index.css, index.html, and foo.ext:
+
+```javascript
+let gulp = require('gulp');
+let gulpTwing = require('gulp-twing');
+let gulpRename = require('gulp-rename');
+
+let Twing = require('twing');
+let loader = new Twing.TwingLoaderFilesystem('/');
+let env = new Twing.TwingEnvironment(loader);
+
+// src contains foo.twig, index.css.twig and index.html.twig
+
+function twing() {
+    gulp.src('src/**/*.twig')
+        .pipe(gulpTwing(env, {foo: 'bar'}, {outputExt: '.ext'}))
+        .pipe(gulpRename(function(path) {
+            if (path.basename.indexOf('.') > -1) {
+                path.extname = '';
+            }
+        }))
+        .pipe(gulp.dest('dest'))
+}
+
+// dest will contain foo.ext, index.css and index.html
 ```
 
 ## Contributing


### PR DESCRIPTION
Follows up on my experience following the README examples (#5)

- fleshes out the documentation, providing standard-syntax gulp examples
- adds note about gulp 4 syntax
- adds note about older gulp syntax, as a refresher for anyone experimenting with using gulp-twing in older projects
- uses `var` instead of `let` to match the unofficial gulp documentation standard, including gulp's own documentation (a tiny thing, not necessary, and debatable, but it's nice to have that community consistency)
- does a little renaming in the examples, because the unofficial gulp standard is to require `gulp-x` as `x`
- moves the shared imports to the top of Examples, to save space
- only provides a `data` object when it's necessary
- adds the Node requirement
- links Twig and gulp